### PR TITLE
Fixed a missing rename variable

### DIFF
--- a/backup/moodle2/restore_lticustom_activity_task.class.php
+++ b/backup/moodle2/restore_lticustom_activity_task.class.php
@@ -67,7 +67,7 @@ class restore_lticustom_activity_task extends restore_activity_task {
      */
     protected function define_my_steps() {
         // Label only has one structure step.
-        $this->add_step(new restore_lti_activity_structure_step('lticustom_structure', 'lticustom.xml'));
+        $this->add_step(new restore_lticustom_activity_structure_step('lticustom_structure', 'lticustom.xml'));
     }
 
     /**


### PR DESCRIPTION
This change solve the problem with the restore process that I found when I was testing in the pluginstaging instace.

I didn't see that variable and I'm missing changing it.